### PR TITLE
Update sw.js

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -14,7 +14,7 @@ workbox.routing.registerRoute(
 
 // handle POSTS to the share form with backgroundSync
 workbox.routing.registerRoute(
-	/share.html/,
+	/success.html/,
 	new workbox.strategies.NetworkOnly({
 		plugins: [
 			new workbox.backgroundSync.Plugin('shareQueue', {


### PR DESCRIPTION
I made success.html the action of the share.html form but I forgot to update the workbox cacche config. This change attempts to get POSTS to the success.html page to be handled by the network only and if possible using background sync.